### PR TITLE
fix: conformiteit implementatiemodellen beschreven

### DIFF
--- a/site-skeleton/doc/begeleidend/implementatiemodellen/conformiteit/index.html
+++ b/site-skeleton/doc/begeleidend/implementatiemodellen/conformiteit/index.html
@@ -2,26 +2,25 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 <html><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 
-<title>Conformiteit Applicatieprofielen</title>
+<title>Conformiteit Implementatiemodellen</title>
 </head>
 <body>
-<h1>Conformiteit Applicatieprofielen</h1>
-  <p>Een applicatieprofiel is een specificatie voor gegevensuitwisseling dat bijkomende beperkingen introduceert voor het toepassen van vocabularia.
-        Dergelijke bijkomende beperkingen kunnen de volgende elementen bevatten:</p>
+<h1>Conformiteit Implementatiemodellen</h1>
+  <p>Een implementatiemodel is een specificatie voor gegevensuitwisseling dat bijkomende beperkingen samen met implementatie-specifieke klassen en eigenschappen introduceert bovenop het applicatieprofiel en vocabularia waarop het implementatiemodel gebaseerd is, gericht op een specifieke implementatie. Dergelijke bijkomende beperkingen kunnen de volgende elementen bevatten:</p>
         <p>
         <ul>
         <li>verfijning van de terminologie (klassen en eigenschappen) consistent met de semantiek uit de betreffende specificaties met een welbepaald gebruik als doel;</li>
-        <li>externe terminologie (klassen en eigenschappen) gebruikt voor nieuwe/extra termen die niet in de bestaande vocabularia voorkomen.</li>
+        <li>externe terminologie (klassen en eigenschappen) gebruikt voor nieuwe/extra termen die niet in de bestaande vocabularia en applicatieprofielen voorkomen.</li>
         </ul>
         </p>
-        <p>Om conform te zijn met dit applicatieprofiel, geldt voor een implementatie dat ze:</p>
+        <p>Om conform te zijn met dit implementatiemodel, geldt voor een implementatie dat ze:</p>
         <p>
         <ul>
         <li>MOET Voor elke klasse steeds de eigenschappen bevatten die als minimum kardinaliteit 1 hebben.</li>
         <li>MAG NIET meer dan 1 instantie bevatten van eigenschappen die 1 als maximum kardinaliteit hebben.</li>
-        <li>MAG terminologie (klassen en eigenschappen) gebruiken op een manier die consistent is met haar semantiek (definitie, gebruik, domein en bereik).</li>
-        <li>MAG NIET terminologie van andere gecontroleerde vocabularia gebruiken dan diegene die gedefinieerd wordt in dit applicatieprofiel.</li>
-        <li>MAG uitgebreid worden met klassen en eigenschappen van andere datamodellen (vocabularia) die niet overlappen met terminologie uit dit applicatieprofiel.</li>
+        <li>MOET terminologie (klassen en eigenschappen) gebruiken op een manier die consistent is met haar semantiek (definitie, gebruik, domein en bereik).</li>
+        <li>MAG NIET terminologie van andere gecontroleerde vocabularia gebruiken dan diegene die gedefinieerd wordt in dit implementatiemodel.</li>
+        <li>MAG uitgebreid worden met klassen en eigenschappen van andere datamodellen (vocabularia of applicatieprofielen) die niet overlappen met terminologie uit dit implementatieprofiel</li>
         </ul>
         </p>
 </body>


### PR DESCRIPTION
Confirmiteitsdocument van implementatiemodellen was een pure kopie van applicatieprofielen en dat is natuurlijk fout. Pas het aan zodat het juiste document weergegeven is op data.vlaanderen.be